### PR TITLE
#getStreamURL returns 404 Resolve.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.felixgail</groupId>
   <artifactId>gplaymusic</artifactId>
-  <version>0.3.8</version>
+  <version>0.3.8-patch</version>
   <packaging>jar</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <url>https://github.com/felixgail/gplaymusic</url>

--- a/src/main/java/com/github/felixgail/gplaymusic/model/Track.java
+++ b/src/main/java/com/github/felixgail/gplaymusic/model/Track.java
@@ -202,9 +202,8 @@ public class Track extends Signable implements Result, Serializable, Model {
 
   @Override
   public String getID() {
-    return getStoreId().orElseGet(
-        () -> getUuid().orElseThrow(
-            () -> new NullPointerException("Track contains neither StoreID nor UUID.")));
+    return getUuid().orElseThrow(
+            () -> new NullPointerException("Track doesn't contains UUID."));
   }
 
   public Optional<String> getStoreId() {


### PR DESCRIPTION
Version 0.3.8-patch
#45 
When getting StreamUrl some tracks will return the StoreID instead of UUID, causing error:


java.io.IOException: "Track does not contain a valid WentryID. This means this track was not taken from a Station!"
	at com.github.felixgail.gplaymusic.model.Track.getStationTrackURL(Track.java:329)
	at com.github.felixgail.gplaymusic.model.Track.getStreamURL(Track.java:308)
	at com.d3coding.gmusicapimak.callMusic.<init>(callMusic.java:136)
	at com.d3coding.gmusicapimak.gmusicinit.main(gmusicinit.java:5)
